### PR TITLE
Import daisyui plugin in tailwind.config.js

### DIFF
--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -1,3 +1,4 @@
+import daisyui from "daisyui";
 
 // ! DaisyUI
 /** @type {import('tailwindcss').Config} */
@@ -6,9 +7,8 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [require('daisyui')],
+  plugins: [daisyui],
 };
-
 
 // ! Flowbite
 // /** @type {import('tailwindcss').Config} */


### PR DESCRIPTION
The tailwind.config.js file was modified to import the daisyui plugin, allowing us to use the daisyui library in our Tailwind CSS configuration. This provides additional utility classes and components.